### PR TITLE
fix: required Python version in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,8 +11,7 @@ classifiers =
 
 [options]
 packages = find:
-install_requires =
-    python_version>="3.7"
+python_requires = >=3.7
 
 [options.extras_require]
 develop =


### PR DESCRIPTION
Fix to the [issue #5](https://github.com/ZettaAI/samwise/issues/5)